### PR TITLE
Pitch selection single border fix

### DIFF
--- a/src/components/Lomake.tsx
+++ b/src/components/Lomake.tsx
@@ -4,6 +4,9 @@ import FormField from './FormField';
 
 import './Lomake.css';
 
+const PITCH_OPTIONS = ['-2', '-1', '0', '+1', '+2'] as const;
+const DEFAULT_PITCH = '0';
+
 export default function Lomake() {
   return (
     <>
@@ -29,7 +32,7 @@ export default function Lomake() {
           </select>
         </FormField>
 
-        <PitchSelection options={['-1', '0', '+1']} defaultOption={'0'} />
+        <PitchSelection options={PITCH_OPTIONS} defaultOption={DEFAULT_PITCH} />
 
         <PersonalInfoCheckbox />
 

--- a/src/components/PitchSelection.css
+++ b/src/components/PitchSelection.css
@@ -6,16 +6,11 @@ ul {
   border: var(--border-width) solid var(--color-border-dark);
 }
 
-li:first-child {
-  border: none;
-}
-
 li:last-child {
   border: none;
 }
 
 li {
-  border-left: var(--border-width) solid var(--color-border-dark);
   border-right: var(--border-width) solid var(--color-border-dark);
 }
 

--- a/src/components/PitchSelection.tsx
+++ b/src/components/PitchSelection.tsx
@@ -2,17 +2,15 @@ import { useState } from 'react';
 import FormField from './FormField';
 import './PitchSelection.css';
 
-// Why not numbers? Might change later, more brittle
-
-// Can I choose String as default?
-// Does this help anything? Maybe with union types?
-// TEST!
-interface GenericPitchSelectionProps<T extends string> {
-  options: T[];
-  defaultOption: T;
+// Might be an easier option? But what I want: a tsc error if the defaultOption is not possible...
+interface GenericPitchSelectionProps<R extends string, T extends readonly R[]> {
+  options: T;
+  defaultOption: T[number];
 }
 
-export default function PitchSelection<T extends string>(props: GenericPitchSelectionProps<T>) {
+export default function PitchSelection<R extends string, T extends readonly R[]>(
+  props: GenericPitchSelectionProps<R, T>,
+) {
   const { options, defaultOption } = props;
 
   // Do the tests in one function?


### PR DESCRIPTION
Earlier most of the elements had double borders on the side. This is now fixed by only applying the right border to every child except the last one.

Also changed the type of props that the pitch selection accepts. Current implementation seems probably unnecessarily complex, but it can give useful compile-time errors if the default option is not contained in the options.