### PR TITLE
Removed radio button input from layout

### DIFF
--- a/src/components/PitchSelection.css
+++ b/src/components/PitchSelection.css
@@ -38,6 +38,7 @@ legend {
   min-width: 1.8rem;
   transition: all 0.2s;
   color: var(--color-border-medium);
+  text-align: center;
 }
 
 .radio-button-container:last-child {
@@ -51,6 +52,7 @@ legend {
 
 .radio-button-container input {
   appearance: none;
+  margin: 0;
 }
 
 .radio-button-container-selected {


### PR DESCRIPTION
Earlier had a top margin, and pushed the label to the right of the center.